### PR TITLE
fixed https_validate_certificates==False for python 2.7.9

### DIFF
--- a/boto/connection.py
+++ b/boto/connection.py
@@ -617,6 +617,9 @@ class AWSAuthConnection(object):
                         host, ca_certs=self.ca_certificates_file,
                         **self.http_connection_kwargs)
             else:
+                if "context" not in self.http_connection_kwargs and \
+                   hasattr(ssl, "_create_unverified_context"):
+                    self.http_connection_kwargs["context"] = ssl._create_unverified_context()
                 connection = httplib.HTTPSConnection(host,
                         **self.http_connection_kwargs)
         else:


### PR DESCRIPTION
https_validate_certificates==False stopped working because of:
https://docs.python.org/2/library/httplib.html#httplib.HTTPSConnection