### PR TITLE
makefile: ability to build develop rpm package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,21 @@ PROJECT    ?= boto
 PACKAGE    := python-$(PROJECT)
 VERSION    := $(shell rpm -q --qf "%{version}\n" --specfile $(PACKAGE).spec | head -1)
 
-clean:
-	@rm -rf build dist $(PROJECT).egg-info $(PROJECT)-*.tar.gz *.egg *.src.rpm
+GIT        := $(shell which git)
+
+ifdef GIT
+SHA := $(shell git rev-parse --short --verify HEAD)
+TAG := $(shell git show-ref --tags -d | grep $(SHA) |\
+	git name-rev --tags --name-only $$(awk '{ print $2 }'))
+endif
 
 sources: clean
+ifndef TAG
+	$(eval SHA_DATE :=  $(shell git show -s --format=%ci $(SHA)))
+	$(eval BUILDID  := .$(shell date --date='$(SHA_DATE)' '+%Y%m%d%H%M').git$(SHA))
+	$(eval BUILDREG := "s/(%define[[:space:]]*buildid[[:space:]]*).*/\\1$(BUILDID)/i")
+	@git cat-file -p $(SHA):$(PACKAGE).spec | sed -r -e $(BUILDREG) > $(PACKAGE).spec
+endif
 	@git archive --format=tar --prefix="$(PROJECT)-$(VERSION)/" \
 		$(shell git rev-parse --verify HEAD) | gzip > $(PROJECT)-$(VERSION).tar.gz
 
@@ -17,3 +28,6 @@ srpm: sources
 
 tests:
 	@tox
+
+clean:
+	@rm -rf build dist $(PROJECT).egg-info $(PROJECT)-*.tar.gz *.egg *.src.rpm

--- a/python-boto.spec
+++ b/python-boto.spec
@@ -4,11 +4,12 @@
 %endif
 
 %define pkgname boto
+%define buildid %{nil}
 
 Summary:        A simple lightweight interface to Amazon Web Services
 Name:           python-%{pkgname}
 Version:        2.12.0
-Release:        CROC2%{?dist}
+Release:        CROC2%{?buildid}%{?dist}
 Epoch:          1441065600
 
 Group:          Development/Languages


### PR DESCRIPTION
Release builds (with tag): `python-boto-%ver-CROC#.%dist.rpm`
Devel builds (without tag): `python-boto-%ver-CROC#.%Y%m%d%H%M.git%sha.%dist.rpm`