### PR TITLE
ec2: fix 'AllowReassociation' param according to AWS API

### DIFF
--- a/boto/ec2/address.py
+++ b/boto/ec2/address.py
@@ -93,7 +93,7 @@ class Address(EC2Object):
 
     delete = release
 
-    def associate(self, instance_id=None, network_interface_id=None, private_ip_address=None, allow_reassociation=False, dry_run=False):
+    def associate(self, instance_id=None, network_interface_id=None, private_ip_address=None, allow_reassociation=None, dry_run=False):
         """
         Associate this Elastic IP address with a currently running instance.
         :see: :meth:`boto.ec2.connection.EC2Connection.associate_address`

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -1929,7 +1929,7 @@ class EC2Connection(AWSQueryConnection):
 
     def _associate_address(self, status, instance_id=None, public_ip=None,
                            allocation_id=None, network_interface_id=None,
-                           private_ip_address=None, allow_reassociation=False,
+                           private_ip_address=None, allow_reassociation=None,
                            dry_run=False,
                            private_ip_address_id=None):
         params = {}
@@ -1947,10 +1947,10 @@ class EC2Connection(AWSQueryConnection):
         if private_ip_address is not None:
             params['PrivateIpAddress'] = private_ip_address
 
-        if allow_reassociation:
-            params['AllowReassociation'] = 'true'
+        if allow_reassociation is not None:
+            params['AllowReassociation'] = allow_reassociation
 
-        elif private_ip_address_id is not None:
+        if private_ip_address_id is not None:
                 params['PrivateIpAddressId'] = private_ip_address_id
 
         if dry_run:
@@ -1964,7 +1964,7 @@ class EC2Connection(AWSQueryConnection):
 
     def associate_address(self, instance_id=None, public_ip=None,
                           allocation_id=None, network_interface_id=None,
-                          private_ip_address=None, allow_reassociation=False,
+                          private_ip_address=None, allow_reassociation=None,
                           dry_run=False,
                           private_ip_address_id=None):
         """
@@ -2018,7 +2018,7 @@ class EC2Connection(AWSQueryConnection):
 
     def associate_address_object(self, instance_id=None, public_ip=None,
                                  allocation_id=None, network_interface_id=None,
-                                 private_ip_address=None, allow_reassociation=False,
+                                 private_ip_address=None, allow_reassociation=None,
                                  dry_run=False,
                                  private_ip_address_id=None):
         """

--- a/tests/unit/ec2/test_address.py
+++ b/tests/unit/ec2/test_address.py
@@ -34,7 +34,7 @@ class AddressTest(unittest.TestCase):
         self.address.connection.associate_address.assert_called_with(
             instance_id=1,
             public_ip="192.168.1.1",
-            allow_reassociation=False,
+            allow_reassociation=None,
             network_interface_id=None,
             private_ip_address=None,
             dry_run=False
@@ -83,7 +83,7 @@ class AddressWithAllocationTest(unittest.TestCase):
             allocation_id="aid1",
             network_interface_id=None,
             private_ip_address=None,
-            allow_reassociation=False,
+            allow_reassociation=None,
             dry_run=False
         )
 
@@ -130,7 +130,7 @@ class AddressWithNetworkInterfaceTest(unittest.TestCase):
             network_interface_id=1,
             private_ip_address=None,
             allocation_id="aid1",
-            allow_reassociation=False,
+            allow_reassociation=None,
             dry_run=False
         )
 


### PR DESCRIPTION
http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateAddress.html

Signed-off-by: Anton Vazhnetsov <dragen15051@gmail.com>