### PR TITLE
travis: pin ubuntu dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: python
 python:
   - "2.6"


### PR DESCRIPTION
in latest travis [update](https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476) default dist was changed to ubuntu 16.10 which lacks python 2.6 and 3.3.
this pr pinned older ubuntu version which supports 2.6 and 3.3 python.
 