### PR TITLE
ec2: add filters for get_all_public_ipv4_pools

### DIFF
--- a/boto/ec2/address.py
+++ b/boto/ec2/address.py
@@ -20,10 +20,10 @@
 # IN THE SOFTWARE.
 
 
-from boto.ec2.ec2object import EC2Object
+from boto.ec2.ec2object import TaggedEC2Object
 
 
-class Address(EC2Object):
+class Address(TaggedEC2Object):
     """
     Represents an EC2 Elastic IP Address
 

--- a/boto/ec2/address_pool.py
+++ b/boto/ec2/address_pool.py
@@ -1,10 +1,10 @@
 '''Croc Cloud EC2 Address Pool.'''
 
 
-from boto.ec2.ec2object import EC2Object
+from boto.ec2.ec2object import EC2Object, TaggedEC2Object
 
 
-class AddressPool(EC2Object):
+class AddressPool(TaggedEC2Object):
 
     def __init__(self, connection=None, id=None):
         super(AddressPool, self).__init__(connection)

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -2281,7 +2281,8 @@ class EC2Connection(AWSQueryConnection):
 
     # Address pools methods
 
-    def get_all_public_ipv4_pools(self, pool_ids=None, next_token=None, max_results=None):
+    def get_all_public_ipv4_pools(self, pool_ids=None, next_token=None, max_results=None,
+                                  filters=None):
         """Describes the specified IPv4 address pools.
 
         :type pool_ids: list
@@ -2295,6 +2296,12 @@ class EC2Connection(AWSQueryConnection):
                             a single call. To retrieve the remaining results,
                             make another call with the returned nextToken value.
 
+        :type filters: dict
+        :param filters: Optional filters that can be used to limit the
+            results returned.  Filters are provided in the form of a
+            dictionary consisting of filter names as the key and
+            filter values as the value.
+
         :rtype: list of :class:`boto.ec2.address_pool.AddressPool
         :return: Information about the address pools.
         """
@@ -2306,6 +2313,8 @@ class EC2Connection(AWSQueryConnection):
             params['MaxResults'] = max_results
         if pool_ids:
             self.build_list_params(params, pool_ids, "PoolId")
+        if filters:
+            self.build_filter_params(params, filters)
 
         return self.get_list(
             "DescribePublicIpv4Pools", params, [('item', AddressPool)], verb='POST')

--- a/boto/ec2/keypair.py
+++ b/boto/ec2/keypair.py
@@ -24,17 +24,18 @@ Represents an EC2 Keypair
 """
 
 import os
-from boto.ec2.ec2object import EC2Object
+from boto.ec2.ec2object import TaggedEC2Object
 from boto.exception import BotoClientError
 
 
-class KeyPair(EC2Object):
+class KeyPair(TaggedEC2Object):
 
     def __init__(self, connection=None):
         super(KeyPair, self).__init__(connection)
         self.name = None
         self.fingerprint = None
         self.material = None
+        self.id = None
 
     def __repr__(self):
         return 'KeyPair:%s' % self.name
@@ -46,6 +47,8 @@ class KeyPair(EC2Object):
             self.fingerprint = value
         elif name == 'keyMaterial':
             self.material = value
+        elif name == "keyPairId":
+            self.id = value
         else:
             setattr(self, name, value)
 

--- a/boto/ec2/placementgroup.py
+++ b/boto/ec2/placementgroup.py
@@ -21,17 +21,18 @@
 """
 Represents an EC2 Placement Group
 """
-from boto.ec2.ec2object import EC2Object
+from boto.ec2.ec2object import TaggedEC2Object
 from boto.exception import BotoClientError
 
 
-class PlacementGroup(EC2Object):
+class PlacementGroup(TaggedEC2Object):
 
     def __init__(self, connection=None, name=None, strategy=None, state=None):
         super(PlacementGroup, self).__init__(connection)
         self.name = name
         self.strategy = strategy
         self.state = state
+        self.id = None
 
     def __repr__(self):
         return 'PlacementGroup:%s' % self.name
@@ -43,6 +44,8 @@ class PlacementGroup(EC2Object):
             self.strategy = value
         elif name == 'state':
             self.state = value
+        elif name == "groupId":
+            self.id = value
         else:
             setattr(self, name, value)
 


### PR DESCRIPTION
[DescribePublicIpv4Pools](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribePublicIpv4Pools.html) have filters param but get_all_public_ipv4_pools doesn't have it.

Changes
*EC2Connection.get_all_public_ipv4_pools*
 * added _filter_ argument, addition to request params if filters present

*Address* is now based on TaggedEC2Object

*AddressPool* is now based on TaggedEC2Object

*KeyPairs* is now based on TaggedEC2Object, and parses *keyPairId* as .id

*Placement* is now based on TaggedEC2Object, and parses *groupId* as .id