### PR TITLE
C2DEVEL-9093: remove description from run_instances

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -1181,7 +1181,6 @@ class EC2Connection(AWSQueryConnection):
             * groupSet
             * ebsOptimized
             * sriovNetSupport
-            * description
 
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -762,7 +762,7 @@ class EC2Connection(AWSQueryConnection):
                       dry_run=False,
                       high_available=None,
                       root_device_name=None, public_addressing=None,
-                      virtualization_type=None, description=None,
+                      virtualization_type=None,
                       private_dns_name=None, switch_ids=None,
                       instance_tags=None, volume_tags=None):
         """
@@ -929,9 +929,6 @@ class EC2Connection(AWSQueryConnection):
         :type virtualization_type: string
         :param virtualization_type: Instance virtualization type (kvm-virtio|kvm-legacy).
 
-        :type description: string
-        :param description: Instance description.
-
         :type switch_ids: list
         :param switch_ids: list of virtual switch IDs
 
@@ -1019,8 +1016,6 @@ class EC2Connection(AWSQueryConnection):
             params['AddressingType'] = 'public' if public_addressing else 'private'
         if virtualization_type:
             params['VirtualizationType'] = virtualization_type
-        if description:
-            params['Description'] = description
         if private_dns_name:
             params['PrivateDnsName'] = private_dns_name
         if switch_ids:


### PR DESCRIPTION
Changes: 
*ec2.connection.run_instances* - Remove description argument
Explanation: Description is a tag from now on