### PR TITLE
EC2, VPC: Tagging on creation

### DIFF
--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -3301,7 +3301,7 @@ class EC2Connection(AWSQueryConnection):
                              [('item', SecurityGroup)], verb='POST')
 
     def create_security_group(self, name, description, vpc_id=None,
-                              dry_run=False):
+                              dry_run=False, tags=None):
         """
         Create a new security group for your account.
         This will create the security group within the region you
@@ -3319,6 +3319,9 @@ class EC2Connection(AWSQueryConnection):
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
+        :type tags: list of dicts
+        :param tags to apply to created security group.
+
         :rtype: :class:`boto.ec2.securitygroup.SecurityGroup`
         :return: The newly created :class:`boto.ec2.securitygroup.SecurityGroup`.
         """
@@ -3329,7 +3332,8 @@ class EC2Connection(AWSQueryConnection):
             params['VpcId'] = vpc_id
         if dry_run:
             params['DryRun'] = 'true'
-
+        if tags:
+            params.update(tags_to_tag_specification(tags, 'security-group'))
         group = self.get_object('CreateSecurityGroup', params,
                                 SecurityGroup, verb='POST')
         group.name = name

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -4772,7 +4772,7 @@ class EC2Connection(AWSQueryConnection):
                              [('item', NetworkInterface)], verb='POST')
 
     def create_network_interface(self, subnet_id, private_ip_address=None,
-                                 description=None, groups=None, dry_run=False):
+                                 description=None, groups=None, dry_run=False, tags=None):
         """
         Creates a network interface in the specified subnet.
 
@@ -4796,6 +4796,9 @@ class EC2Connection(AWSQueryConnection):
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
+        :type tags: list of dicts
+        :param tags to apply to created network interface.
+
         :rtype: :class:`boto.ec2.networkinterface.NetworkInterface`
         :return: The newly created network interface.
         """
@@ -4814,6 +4817,8 @@ class EC2Connection(AWSQueryConnection):
             self.build_list_params(params, ids, 'SecurityGroupId')
         if dry_run:
             params['DryRun'] = 'true'
+        if tags:
+            params.update(tags_to_tag_specification(tags, 'network-interface'))
         return self.get_object('CreateNetworkInterface', params,
                                NetworkInterface, verb='POST')
 

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -4594,7 +4594,7 @@ class EC2Connection(AWSQueryConnection):
         return self.get_list('DescribePlacementGroups', params,
                              [('item', PlacementGroup)], verb='POST')
 
-    def create_placement_group(self, name, strategy='cluster', dry_run=False):
+    def create_placement_group(self, name, strategy='cluster', dry_run=False, tags=None):
         """
         Create a new placement group for your account.
         This will create the placement group within the region you
@@ -4610,12 +4610,17 @@ class EC2Connection(AWSQueryConnection):
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
+        :type tags: list of dicts
+        :param tags to apply to created placement group.
+
         :rtype: bool
         :return: True if successful
         """
         params = {'GroupName': name, 'Strategy': strategy}
         if dry_run:
             params['DryRun'] = 'true'
+        if tags:
+            params.update(tags_to_tag_specification(tags, 'placement-group'))
         group = self.get_status('CreatePlacementGroup', params, verb='POST')
         return group
 

--- a/boto/ec2/connection.py
+++ b/boto/ec2/connection.py
@@ -75,6 +75,8 @@ from boto.compat import six
 from boto.ec2.export_task import ExportTask, ExportVolumeTask
 from boto.ec2.import_task import ImportImageTask, ImportSnapshotTask
 from boto.ec2.virtualswitch import VirtualSwitch
+from boto.utils import tags_to_tag_specification
+
 
 #boto.set_stream_logger('ec2')
 
@@ -1026,15 +1028,9 @@ class EC2Connection(AWSQueryConnection):
         if switch_ids:
             self.build_list_params(params, switch_ids, 'SwitchId')
         if instance_tags:
-            params["TagSpecification.0.ResourceType"] = "instance"
-            for tag_n, tag in enumerate(instance_tags):
-                params["TagSpecification.0.Tag.{0}.Key".format(tag_n)] = tag["key"]
-                params["TagSpecification.0.Tag.{0}.Value".format(tag_n)] = tag["value"]
+            params.update(tags_to_tag_specification(instance_tags, 'instance'))
         if volume_tags:
-            params["TagSpecification.1.ResourceType"] = "volume"
-            for tag_n, tag in enumerate(volume_tags):
-                params["TagSpecification.1.Tag.{0}.Key".format(tag_n)] = tag["key"]
-                params["TagSpecification.1.Tag.{0}.Value".format(tag_n)] = tag["value"]
+            params.update(tags_to_tag_specification(volume_tags, 'volume', specification_id=1))
         return self.get_object('RunInstances', params, Reservation,
                                verb='POST')
 
@@ -2619,10 +2615,7 @@ class EC2Connection(AWSQueryConnection):
         if dry_run:
             params['DryRun'] = 'true'
         if tags:
-            params["TagSpecification.0.ResourceType"] = "volume"
-            for tag_n, tag in enumerate(tags):
-                params["TagSpecification.0.Tag.{0}.Key".format(tag_n)] = tag["key"]
-                params["TagSpecification.0.Tag.{0}.Value".format(tag_n)] = tag["value"]
+            params.update(tags_to_tag_specification(tags, 'volume'))
         return self.get_object('CreateVolume', params, Volume, verb='POST')
 
     def delete_volume(self, volume_id, dry_run=False):
@@ -2808,10 +2801,7 @@ class EC2Connection(AWSQueryConnection):
         if dry_run:
             params['DryRun'] = 'true'
         if tags:
-            params["TagSpecification.0.ResourceType"] = "snapshot"
-            for tag_n, tag in enumerate(tags):
-                params["TagSpecification.0.Tag.{0}.Key".format(tag_n)] = tag["key"]
-                params["TagSpecification.0.Tag.{0}.Value".format(tag_n)] = tag["value"]
+            params.update(tags_to_tag_specification(tags, 'snapshot'))
         snapshot = self.get_object('CreateSnapshot', params,
                                    Snapshot, verb='POST')
         return snapshot
@@ -3199,10 +3189,7 @@ class EC2Connection(AWSQueryConnection):
         if dry_run:
             params['DryRun'] = 'true'
         if tags:
-            params["TagSpecification.0.ResourceType"] = "key-pair"
-            for tag_n, tag in enumerate(tags):
-                params["TagSpecification.0.Tag.{0}.Key".format(tag_n)] = tag["key"]
-                params["TagSpecification.0.Tag.{0}.Value".format(tag_n)] = tag["value"]
+            params.update(tags_to_tag_specification(tags, 'key-pair'))
 
         return self.get_object('CreateKeyPair', params, KeyPair, verb='POST')
 
@@ -3266,10 +3253,7 @@ class EC2Connection(AWSQueryConnection):
         if dry_run:
             params['DryRun'] = 'true'
         if tags:
-            params["TagSpecification.0.ResourceType"] = "key-pair"
-            for tag_n, tag in enumerate(tags):
-                params["TagSpecification.0.Tag.{0}.Key".format(tag_n)] = tag["key"]
-                params["TagSpecification.0.Tag.{0}.Value".format(tag_n)] = tag["value"]
+            params.update(tags_to_tag_specification(tags, 'key-pair'))
         return self.get_object('ImportKeyPair', params, KeyPair, verb='POST')
 
     # SecurityGroup methods

--- a/boto/utils.py
+++ b/boto/utils.py
@@ -1089,3 +1089,21 @@ def parse_host(hostname):
         return hostname.split(']:', 1)[0].strip('[]')
     else:
         return hostname.split(':', 1)[0]
+
+
+def tags_to_tag_specification(tags, resource_type, specification_id=0):
+    """Transforms tags from list type to TagSpecification format.
+
+    :param list tags: list of dicts. [{"key": ..., "value": ...}].
+    :param str resource_type: tag resource type.
+    :param int specification_id: TagSpecification id.
+    :return: dict: tag specification.
+    """
+
+    params = {'TagSpecification.{0}.ResourceType'.format(specification_id): resource_type}
+    for tag_n, tag in enumerate(tags):
+        params['TagSpecification.{0}.Tag.{1}.Key'.format(
+            specification_id, tag_n)] = tag['key']
+        params['TagSpecification.{0}.Tag.{1}.Value'.format(
+            specification_id, tag_n)] = tag['value']
+    return params

--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -598,17 +598,22 @@ class VPCConnection(EC2Connection):
 
         return self.associate_network_acl(default_acl_id, subnet_id)
 
-    def create_network_acl(self, vpc_id):
+    def create_network_acl(self, vpc_id, tags=None):
         """
         Creates a new network ACL.
 
         :type vpc_id: str
         :param vpc_id: The VPC ID to associate this network ACL with.
 
+        :type tags: list of dicts
+        :param tags to apply to created network ACL.
+
         :rtype: The newly created network ACL
         :return: A :class:`boto.vpc.networkacl.NetworkAcl` object
         """
         params = {'VpcId': vpc_id}
+        if tags:
+            params.update(tags_to_tag_specification(tags, 'network-acl'))
         return self.get_object('CreateNetworkAcl', params, NetworkAcl)
 
     def delete_network_acl(self, network_acl_id):

--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -38,6 +38,7 @@ from boto.vpc.vpc_peering_connection import VpcPeeringConnection
 from boto.ec2 import RegionData
 from boto.regioninfo import RegionInfo, get_regions
 from boto.regioninfo import connect
+from boto.utils import tags_to_tag_specification
 
 
 def regions(**kw_params):
@@ -1158,7 +1159,7 @@ class VPCConnection(EC2Connection):
         return self.get_list('DescribeSubnets', params, [('item', Subnet)])
 
     def create_subnet(self, vpc_id, cidr_block, availability_zone=None,
-                      dry_run=False):
+                      dry_run=False, tags=None):
         """
         Create a new Subnet
 
@@ -1174,6 +1175,9 @@ class VPCConnection(EC2Connection):
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
+        :type tags: list of dicts
+        :param tags to apply to created subnet.
+
         :rtype: The newly created Subnet
         :return: A :class:`boto.vpc.customergateway.Subnet` object
         """
@@ -1183,6 +1187,8 @@ class VPCConnection(EC2Connection):
             params['AvailabilityZone'] = availability_zone
         if dry_run:
             params['DryRun'] = 'true'
+        if tags:
+            params.update(tags_to_tag_specification(tags, 'subnet'))
         return self.get_object('CreateSubnet', params, Subnet)
 
     def create_default_subnet(self, availability_zone, dry_run=False):

--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -111,7 +111,7 @@ class VPCConnection(EC2Connection):
         return self.get_list('DescribeVpcs', params, [('item', VPC)])
 
     def create_vpc(self, cidr_block, instance_tenancy=None, dry_run=False,
-                   description=None):
+                   description=None, tags=None):
         """
         Create a new Virtual Private Cloud.
 
@@ -128,6 +128,9 @@ class VPCConnection(EC2Connection):
         :type description: string
         :param description: Description of the VPC.
 
+        :type tags: list of dicts
+        :param tags to apply to created VPC.
+
         :rtype: The newly created VPC
         :return: A :class:`boto.vpc.vpc.VPC` object
         """
@@ -138,6 +141,8 @@ class VPCConnection(EC2Connection):
             params['DryRun'] = 'true'
         if description:
             params['Description'] = description
+        if tags:
+            params.update(tags_to_tag_specification(tags, 'vpc'))
         return self.get_object('CreateVpc', params, VPC)
 
     def delete_vpc(self, vpc_id, dry_run=False):

--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -1263,7 +1263,7 @@ class VPCConnection(EC2Connection):
 
     def create_dhcp_options(self, domain_name=None, domain_name_servers=None,
                             ntp_servers=None, netbios_name_servers=None,
-                            netbios_node_type=None, dry_run=False):
+                            netbios_node_type=None, dry_run=False, tags=None):
         """
         Create a new DhcpOption
 
@@ -1294,6 +1294,9 @@ class VPCConnection(EC2Connection):
 
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
+
+        :type tags: list of dicts
+        :param tags to apply to created dhcp options
 
         :rtype: The newly created DhcpOption
         :return: A :class:`boto.vpc.customergateway.DhcpOption` object
@@ -1332,6 +1335,9 @@ class VPCConnection(EC2Connection):
                                         'netbios-node-type', netbios_node_type)
         if dry_run:
             params['DryRun'] = 'true'
+
+        if tags:
+            params.update(tags_to_tag_specification(tags, 'dhcp-options'))
 
         return self.get_object('CreateDhcpOptions', params, DhcpOptions)
 

--- a/boto/vpc/__init__.py
+++ b/boto/vpc/__init__.py
@@ -276,7 +276,7 @@ class VPCConnection(EC2Connection):
             params['DryRun'] = 'true'
         return self.get_status('DisassociateRouteTable', params)
 
-    def create_route_table(self, vpc_id, dry_run=False):
+    def create_route_table(self, vpc_id, dry_run=False, tags=None):
         """
         Creates a new route table.
 
@@ -286,12 +286,17 @@ class VPCConnection(EC2Connection):
         :type dry_run: bool
         :param dry_run: Set to True if the operation should not actually run.
 
+        :type tags: list of dicts
+        :param tags to apply to created route table.
+
         :rtype: The newly created route table
         :return: A :class:`boto.vpc.routetable.RouteTable` object
         """
         params = {'VpcId': vpc_id}
         if dry_run:
             params['DryRun'] = 'true'
+        if tags:
+            params.update(tags_to_tag_specification(tags, 'route-table'))
         return self.get_object('CreateRouteTable', params, RouteTable)
 
     def delete_route_table(self, route_table_id, dry_run=False):


### PR DESCRIPTION
Changes: 
Added option for tagging on creation for:
* ACLs
* DHCP options
* Network interfaces
* Placement groups
* Route tables
* Security groups
* Subnets
* VPCs