### PR TITLE
VPC: remove unused vpc.description attribute

### DIFF
--- a/boto/vpc/vpc.py
+++ b/boto/vpc/vpc.py
@@ -39,7 +39,6 @@ class VPC(TaggedEC2Object):
         :ivar is_default: Indicates whether the VPC is the default VPC.
         :ivar instance_tenancy: The allowed tenancy of instances launched into the VPC.
         :ivar classic_link_enabled: Indicates whether ClassicLink is enabled.
-        :ivar description: Description of the VPC.
         """
         super(VPC, self).__init__(connection)
         self.id = None
@@ -49,7 +48,6 @@ class VPC(TaggedEC2Object):
         self.is_default = None
         self.instance_tenancy = None
         self.classic_link_enabled = None
-        self.description = None
 
     def __repr__(self):
         return 'VPC:%s' % self.id
@@ -69,8 +67,6 @@ class VPC(TaggedEC2Object):
             self.instance_tenancy = value
         elif name == 'classicLinkEnabled':
             self.classic_link_enabled = value
-        elif name == 'description':
-            self.description = value
         else:
             setattr(self, name, value)
 


### PR DESCRIPTION
__Changes__: 
1. removed `.description` attribute from VPC 